### PR TITLE
Fix: resolve image rendering issue by defining remote host

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,12 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        hostname: "loremflickr.com",
+      },
+    ],
+  },
+};
 
 export default nextConfig;

--- a/src/app/types/products.ts
+++ b/src/app/types/products.ts
@@ -3,5 +3,6 @@ export type ProductsUser = {
   name: string;
   description: string;
   image: string;
+
   category: string;
 };


### PR DESCRIPTION
- Fixed error caused by missing host definition in image rendering
- Modified ` Next.config.tsx` to include ` remotePatterns` for image source configuration, as it is not deprecated.